### PR TITLE
app.js: accept new timestamp argument.

### DIFF
--- a/app.js
+++ b/app.js
@@ -71,6 +71,10 @@ function getActivity(db){
     })
 }
 
+function argDateParse(date) {
+    return moment(new Date(new Date() - (date * 1000 * 60)))
+}
+
 function strToDb(str){
     return str.replace("'", "''")
 }
@@ -134,7 +138,9 @@ client.on('message', async message => {
                     exp_id  = 5
                     break;
             }
-            
+            if (args[0].startsWith('-') && args[0].length > 1) {
+                time = argDateParse(args.shift().slice(1))
+            }
             let desc    = args.join(' ')
 
             let sql = `INSERT INTO trn_train (
@@ -182,4 +188,4 @@ client.on('message', async message => {
 
 });
 
-client.login(process.env.BOT_TOKEN); 
+client.login(process.env.BOT_TOKEN);


### PR DESCRIPTION
new timestamp argument is parsed, always in minutes, in case the first argument after the bot command starts with the prefix '-' denoting that the event happened in 'minus' X minutes, eg. `.ew -29 today was packed!`, is parsed as the last endwalker train ended 29 minutes ago with 'today was packed!' as the comment, if the prefix is not found the following process is skipped entirely
timestamp parsing implementation is done by using subtraction on current unix timestamp from Date() after converting the argument received to the proper unit of time for subtraction